### PR TITLE
Adds ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# OS cache files
+.DS_Store
+._.*
+Thumbs.db


### PR DESCRIPTION
Basic ignore rules to exclude OSX Finder's cache files and Windows' Thumbs.db;
