### PR TITLE
Fixed dead link in the nine-patch generator screen.

### DIFF
--- a/app/content/pencil/n-patch/9patch.html
+++ b/app/content/pencil/n-patch/9patch.html
@@ -117,7 +117,7 @@
                 Pencil supports parsing and embedding scalable n-Patch format that is used in the Google Android OS. More information:<br/>
                 <ul>
                     <li><a href="http://developer.android.com/guide/topics/graphics/2d-graphics.html#nine-patch">About Android n-Patch format</a></li>
-                    <li><a href="http://www.pencil-project.org/wiki/devguide/Tutorial/Nine_Patches.html">Using n-Patches in Pencil stencils</a></li>
+                    <li><a href="http://pencil-prototyping.readthedocs.org/en/develop/devguide/tutorial/ninepatch.html">Using n-Patches in Pencil stencils</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
I noticed when I was touching up the docs yesterday that it was going to a completely dead link (didn't even redirect to the Evolus site). I've changed it to go to the new documentation location.
