### PR TITLE
added example/context to setup function

### DIFF
--- a/app/content/pencil/common/pencil.js
+++ b/app/content/pencil/common/pencil.js
@@ -289,7 +289,7 @@ Pencil.setupCommands = function () {
          ``mainWindow.xul``.
          
          Called e.g. if an element is selected in order to provide applicable commands. 
-.........
+         
          Whether a command is activated or deactivated depends on the state of
          the application(if a document has been created, if there is an active
          ``canvas`` element, etc.) and the active element (e.g. a selected stencil)

--- a/app/content/pencil/common/pencil.js
+++ b/app/content/pencil/common/pencil.js
@@ -287,10 +287,12 @@ Pencil.setupCommands = function () {
          Activates & deactivates commands via the :func:`Pencil._enableCommand`
          function along with the ids of the ``<command>`` XUL Elements from
          ``mainWindow.xul``.
-
+         
+         Called e.g. if an element is selected in order to provide applicable commands. 
+.........
          Whether a command is activated or deactivated depends on the state of
          the application(if a document has been created, if there is an active
-         ``canvas`` element, etc.)
+         ``canvas`` element, etc.) and the active element (e.g. a selected stencil)
     */
 
     var canvas = Pencil.activeCanvas;


### PR DESCRIPTION
I added two brief examples to the setup function in Pencil.setupCommands to give an idea what "state" and "document" mean here. Naturally, it makes it a tiny bit less terse but quicker to understand what this is about imho. 
