### PR TITLE
Comments on the Pencil.setPainterCommandChecked

### DIFF
--- a/app/content/pencil/common/pencil.js
+++ b/app/content/pencil/common/pencil.js
@@ -262,6 +262,12 @@ Pencil.invalidateSharedEditor = function() {
     }
 };
 Pencil.setPainterCommandChecked = function (v) {
+    /*
+    Checks if the format painter tool (used for copying formats of stencils on canvas) 
+    is active. 
+    
+    Called on click on stencils on canvas. 
+    */
     var painterCommand = document.getElementById("toolbarFormatPainterCommand");
     if (painterCommand) {
         painterCommand.checked = v;

--- a/app/content/pencil/common/pencil.js
+++ b/app/content/pencil/common/pencil.js
@@ -262,13 +262,19 @@ Pencil.invalidateSharedEditor = function() {
     }
 };
 Pencil.setPainterCommandChecked = function (v) {
-    /*
-    Checks if the format painter tool (used for copying formats of stencils on canvas) 
-    is active; Removes the painter class from all canvas ("pages" in the GUI) if the
-    painter tool is inactive. 
+    /*"""
+    .. function:: Pencil.setPainterCommandChecked(id)
     
-    Called on click on stencils on canvas. 
+    :param v: boolean; currently only as false; determines state of the format painter function.
+    :returns: undefined
+    
+    Side Effect: If passed value v is false, it deactivates the format painter tool (used for copying formats 
+    of stencils on canvas) 
+    Side Effect: If passed value v is false, it removes the painter class from all canvas ("pages" in the GUI) if passed value v is false. 
+    
+    Called on click on stencils on canvas or if the toolbarFormatPainterCommand button is clicked. 
     */
+
     var painterCommand = document.getElementById("toolbarFormatPainterCommand");
     if (painterCommand) {
         painterCommand.checked = v;

--- a/app/content/pencil/common/pencil.js
+++ b/app/content/pencil/common/pencil.js
@@ -35,7 +35,7 @@ Pencil.registerEditor = function (editorClass) {
 Pencil.sharedEditors = [];
 Pencil.registerSharedEditor = function (sharedEditor) {
     Pencil.sharedEditors.push(sharedEditor);
-}
+};
 
 Pencil.xferHelperClasses = [];
 Pencil.registerXferHelper = function (helperClass) {
@@ -263,16 +263,16 @@ Pencil.invalidateSharedEditor = function() {
 };
 Pencil.setPainterCommandChecked = function (v) {
     /*"""
-    .. function:: Pencil.setPainterCommandChecked(id)
-    
-    :param v: boolean; currently only as false; determines state of the format painter function.
-    :returns: undefined
-    
-    Side Effect: If passed value v is false, it deactivates the format painter tool (used for copying formats 
-    of stencils on canvas) 
-    Side Effect: If passed value v is false, it removes the painter class from all canvas ("pages" in the GUI) if passed value v is false. 
-    
-    Called on click on stencils on canvas or if the toolbarFormatPainterCommand button is clicked. 
+     .. function:: Pencil.setPainterCommandChecked(id)
+
+        :param v: boolean; currently only as false; determines state of the format painter function.
+        :returns: undefined
+
+        Side Effect: If passed value v is false, it deactivates the format painter tool (used for copying formats
+        of stencils on canvas)
+        Side Effect: If passed value v is false, it removes the painter class from all canvas ("pages" in the GUI) if passed value v is false.
+
+        Called on click on stencils on canvas or if the toolbarFormatPainterCommand button is clicked.
     */
 
     var painterCommand = document.getElementById("toolbarFormatPainterCommand");

--- a/app/content/pencil/common/pencil.js
+++ b/app/content/pencil/common/pencil.js
@@ -264,7 +264,8 @@ Pencil.invalidateSharedEditor = function() {
 Pencil.setPainterCommandChecked = function (v) {
     /*
     Checks if the format painter tool (used for copying formats of stencils on canvas) 
-    is active. 
+    is active; Removes the painter class from all canvas ("pages" in the GUI) if the
+    painter tool is inactive. 
     
     Called on click on stencils on canvas. 
     */


### PR DESCRIPTION
Checks if the format painter tool (used for copying formats of stencils on canvas)  is active; Removes the painter class from all canvas ("pages" in the GUI) if the  painter tool is inactive.  
Called on click on stencils on canvas. 
