### PR TITLE
solve bug fixed size in svg export

### DIFF
--- a/app/content/pencil/exporter/Pencil2SVG.xslt
+++ b/app/content/pencil/exporter/Pencil2SVG.xslt
@@ -40,7 +40,9 @@
     <xsl:output method="xml"/>
 
     <xsl:template match="/">
-        <svg width="744.09448819" height="1052.3622047"
+        <!-- Use the dimensions of the first page! -->
+        <svg width="{/p:Document/p:Pages/p:Page/p:Properties/p:Property[@name='width']/text()}" 
+            height="{/p:Document/p:Pages/p:Page/p:Properties/p:Property[@name='height']/text()}"
             id="exportedSVG"
             version="1.1"
             pencil:version="1.2.2"
@@ -51,6 +53,9 @@
         </svg>
     </xsl:template>
     <xsl:template match="p:Page">
+        <!-- Multiple pages in the ep file end up as inkscape layers. 
+        The SVG standard does not support pages nor layers. 
+        All pages/layers are shown in a browser, if the background is transparant! -->
         <g inkscape:label="{p:Properties/p:Property[@name='name']/text()}"
            inkscape:groupmode="layer" id="layer_{p:Properties/p:Property[@name='fid']/text()}">
             <g>


### PR DESCRIPTION
If Pencil exports a SVG file, then the result contains attributes with a fixed size.
In the SVG export file, the first element is:
<svg xmlns="..." width="744.09448819" height="1052.3622047" .....
These dimensions are wrong. Adapting these two values fixes the problem that you will have when using the svg result: If the drawing is bigger, a part is cut of, and if the drawing is smaller, you have too much white space.

See also https://code.google.com/p/evoluspencil/issues/detail?id=456
See also https://code.google.com/p/evoluspencil/issues/detail?id=538

This patch uses the dimensions of the first page for all its pages.

Remark about the multipage aspect:
SVG does not support multiple pages.
Pencil uses the Inkscape extension for multiple layers.
That means that when you view the resulting SVG file in a browser, all pages appear on top of each other.
So, creating a .ep file with multiple pages seems not very usefull to me.
If your .ep files only contain 1 page, then the SVG export function is perfect with this patch.
