### PR TITLE
the svg is multi-layer, not multi-page

### DIFF
--- a/app/content/pencil/exporter/svgExporter.js
+++ b/app/content/pencil/exporter/svgExporter.js
@@ -1,5 +1,5 @@
 function SVGExporter() {
-    this.name = "Multi-page SVG file";
+    this.name = "Multi-layer SVG file";
     this.id = "SVGExporter";
     this.xsltProcessor = new XSLTProcessor();
     this.xsltDOM = null;
@@ -31,7 +31,7 @@ SVGExporter.prototype.export = function (doc, options, destFile, xmlFile, callba
     callback();
 };
 SVGExporter.prototype.getWarnings = function () {
-    return "Document will be exported as a multi-page SVG file that can used in Inkscape.";
+    return "Document will be exported as a multi-layer SVG file that can be used in Inkscape.";
 };
 SVGExporter.prototype.getOutputType = function () {
     return BaseExporter.OUTPUT_TYPE_FILE;


### PR DESCRIPTION
The generated svg is multi-layer, not multi-page.
There is no such thing as multi-page SVG.
Layers are a Inkscape specific feature, so it is better to be clear about it.

If the exported SVG file is made from a one-page project, then it is usable for viewing in a browser.
