### PR TITLE
change the preference from xulrunner to firefox

### DIFF
--- a/build/Linux/pencil
+++ b/build/Linux/pencil
@@ -3,8 +3,8 @@
 # Target for application ini
 APP_INI="/usr/share/evolus-pencil/application.ini"
 
-# List of firefox binaries to search
-BINARIES="xulrunner iceweasel firefox firefox-bin"
+# List of firefox binaries to search in sequence of preference
+BINARIES="iceweasel firefox firefox-bin xulrunner"
 
 # Assembling run command
 RUN=""


### PR DESCRIPTION
This will solve the problem I have with the openSuse package.
There is no newer xulrunner available than version 34 on openSuse currently, and Pencil needs 36.
Changing the preference to Firefox will make Pencil run when both are installed.
