### PR TITLE
Prevent data loss when exporting a file as an existing directory

### DIFF
--- a/app/content/pencil/exportWizard.js
+++ b/app/content/pencil/exportWizard.js
@@ -26,14 +26,14 @@ ExportWizard.setup = function () {
     Dom.empty(ExportWizard.exporterRadioGroup);
 
     var selectedExporterRadioItem = null;
-    
+
     var selectedExporter = null;
     if (ExportWizard.dialogData.forcedExporterId) {
         selectedExporter = ExportWizard.Pencil.getDocumentExporterById(ExportWizard.dialogData.forcedExporterId);
     } else if (lastSelection.exporterId) {
         selectedExporter = ExportWizard.Pencil.getDocumentExporterById(lastSelection.exporterId);
     }
-    
+
     if (!selectedExporter) selectedExporter = ExportWizard.Pencil.defaultDocumentExporter;
 
     for (var i = 0; i < exporters.length; i ++) {
@@ -81,7 +81,7 @@ ExportWizard.setup = function () {
     window.setTimeout(ExportWizard.onPageSelectionChanged, 10);
 
     //Setup templates and other options
-    if (ExportWizard.getSelectedExporter().supportTemplating() && 
+    if (ExportWizard.getSelectedExporter().supportTemplating() &&
             lastSelection.templateId) {
         ExportWizard.templateMenu.value = lastSelection.templateId;
     }
@@ -94,7 +94,7 @@ ExportWizard.setup = function () {
 
     ExportWizard._setupFormatPageDone = true;
     window.sizeToContent();
-    
+
     if (ExportWizard.dialogData.forcedExporterId) {
         document.documentElement.advance();
     }
@@ -238,12 +238,12 @@ ExportWizard.browseTargetFile = function () {
     fp.appendFilter(Util.getMessage("filepicker.all.files"), "*");
 
     if (fp.show() == nsIFilePicker.returnCancel) return;
-    
+
     var path = fp.file.path;
     if (isChoosingFile && defaultExt && path.indexOf(".") < 0) {
         path = path + defaultExt;
     }
-    
+
     ExportWizard.targetFilePathText.value = path;
 };
 ExportWizard.validatePageSelection = function () {
@@ -266,8 +266,15 @@ ExportWizard.validateOptions = function () {
     var exporter = ExportWizard.getSelectedExporter();
 
     if (exporter.getOutputType() != BaseExporter.OUTPUT_TYPE_NONE) {
+        // Display an error message if the given output directory/file is empty
         if (!ExportWizard.targetFilePathText.value) {
-            Util.error(Util.getMessage("error.title"), Util.getMessage("please.select.the.target.directory"), Util.getMessage("button.close.label"));
+            var errorMessage =
+                (exporter.getOutputType() === BaseExporter.OUTPUT_TYPE_FILE) ?
+                    "please.select.the.target.file" :
+                    "please.select.the.target.directory";
+            Util.error(Util.getMessage("error.title"),
+                Util.getMessage(errorMessage),
+                Util.getMessage("button.close.label"));
             ExportWizard.targetFilePathText.focus();
             return false;
         }
@@ -330,4 +337,3 @@ window.onload = function () {
 window.onerror = function (msg, url, lineNumber) {
     error([msg, url, lineNumber]);
 };
-

--- a/app/content/pencil/exportWizard.js
+++ b/app/content/pencil/exportWizard.js
@@ -264,29 +264,38 @@ ExportWizard.validatePageSelection = function () {
 };
 ExportWizard.validateOptions = function () {
     var exporter = ExportWizard.getSelectedExporter();
+    var outputType = exporter.getOutputType();
 
-    if (exporter.getOutputType() != BaseExporter.OUTPUT_TYPE_NONE) {
-        // Display an error message if the given output directory/file is empty
+    if (outputType != BaseExporter.OUTPUT_TYPE_NONE) {
+        // Display an error message if the given output file/directory is empty
         if (!ExportWizard.targetFilePathText.value) {
-            var errorMessage =
-                (exporter.getOutputType() === BaseExporter.OUTPUT_TYPE_FILE) ?
-                    "please.select.the.target.file" :
-                    "please.select.the.target.directory";
+            var errorMessage = (outputType === BaseExporter.OUTPUT_TYPE_FILE) ?
+                                "please.select.the.target.file" :
+                                "please.select.the.target.directory";
             Util.error(Util.getMessage("error.title"),
-                Util.getMessage(errorMessage),
-                Util.getMessage("button.close.label"));
+                       Util.getMessage(errorMessage),
+                       Util.getMessage("button.close.label"));
             ExportWizard.targetFilePathText.focus();
             return false;
         }
 
+        // Create file instance to test properties
         var file = Components.classes["@mozilla.org/file/local;1"]
                              .createInstance(Components.interfaces.nsILocalFile);
         file.initWithPath(ExportWizard.targetFilePathText.value);
 
-        if (!file.parent.exists()) {
-            Util.error(Util.getMessage("error.title"), Util.getMessage("the.specified.path.does.not.exists"), Util.getMessage("button.close.label"));
+        // Ensure the given path is valid
+        var isValidPath = file.parent.exists();
+        if (file.exists()) {
+            // Ensure the file/directory is the correct type if it exists
+            isValidPath &= (outputType === BaseExporter.OUTPUT_TYPE_FILE) ?
+                            file.isFile() : file.isDirectory();
+        }
+        if (!isValidPath) {
+            Util.error(Util.getMessage("error.title"),
+                       Util.getMessage("the.specified.path.is.invalid"),
+                       Util.getMessage("button.close.label"));
             ExportWizard.targetFilePathText.focus();
-
             return false;
         }
     }

--- a/app/locale/en-US/pencil.properties
+++ b/app/locale/en-US/pencil.properties
@@ -97,7 +97,7 @@ select.destination=Select destination
 please.select.at.least.one.page.to.export=Please select at least one page to export
 please.select.the.target.directory=Please select the target directory
 please.select.the.target.file=Please select the target file
-the.specified.path.does.not.exists=The specified path does not exists.
+the.specified.path.is.invalid=The specified path is invalid
 
 #external editor
 unsupported.type=Unsupported type: %S

--- a/app/locale/en-US/pencil.properties
+++ b/app/locale/en-US/pencil.properties
@@ -96,6 +96,7 @@ select.output.file=Select output file
 select.destination=Select destination
 please.select.at.least.one.page.to.export=Please select at least one page to export
 please.select.the.target.directory=Please select the target directory
+please.select.the.target.file=Please select the target file
 the.specified.path.does.not.exists=The specified path does not exists.
 
 #external editor


### PR DESCRIPTION
Fixes #576 and #459. 

When a file (eg. PDF) is exported with the destination path of an existing directory, the directory is destroyed and the file is not created. Although the exporter uses the correct dialog window (file/directory) when `Browse` is clicked, the user is able to manually modify the destination path in the text field, thus necessitating extra validation. 

This fix ensures that if the destination path exists, that it is the correct type (file or directory) required by the selected export type.

Tested on Mac and Windows.
