### PR TITLE
Fix baseRasterizedExporter.js to write correct image URLs

### DIFF
--- a/app/content/pencil/exporter/baseRasterizedExporter.js
+++ b/app/content/pencil/exporter/baseRasterizedExporter.js
@@ -1,32 +1,35 @@
 function BaseRasterizedExporter() {
-    this.name = Util.getMessage("rasterized.graphics.png.files");
-    this.id = "BaseRasterizedExporter";
+  this.name = Util.getMessage("rasterized.graphics.png.files");
+  this.id = "BaseRasterizedExporter";
 }
 BaseRasterizedExporter.prototype = new BaseExporter();
 
-BaseRasterizedExporter.prototype.requireRasterizedData = function () {
-    return true;
+BaseRasterizedExporter.prototype.requireRasterizedData = function() {
+  return true;
 };
-BaseRasterizedExporter.prototype.getRasterizedPageDestination = function (baseDir) {
-    return baseDir.clone();
+BaseRasterizedExporter.prototype.getRasterizedPageDestination = function(
+  baseDir) {
+  return baseDir.clone();
 };
 
-BaseRasterizedExporter.prototype.export = function (doc, options, destFile, xmlFile, callback) {
-    callback();
+BaseRasterizedExporter.prototype.export = function(doc, options, destFile,
+  xmlFile, callback) {
+  callback();
 };
-BaseRasterizedExporter.prototype.getWarnings = function () {
-    return Util.getMessage("no.linkings.are.preserved");
+BaseRasterizedExporter.prototype.getWarnings = function() {
+  return Util.getMessage("no.linkings.are.preserved");
 };
-BaseRasterizedExporter.prototype.fixAbsoluteRasterizedPaths = function (sourceDOM, destDir) {
-    //changing rasterized path to relative
-    var pathPrefix = destDir.path + DirIO.sep;
-    Dom.workOn("//p:Page/@rasterized", sourceDOM, function (attr) {
-        var path = attr.nodeValue;
-        if (path.indexOf(pathPrefix) == 0) {
-            path = path.substring(pathPrefix.length);
-            attr.nodeValue = path;
-        }
-    });
+BaseRasterizedExporter.prototype.fixAbsoluteRasterizedPaths = function(
+  sourceDOM, destDir) {
+  //changing rasterized path to relative
+  var pathPrefix = destDir.path + DirIO.sep;
+  Dom.workOn("//p:Page/@rasterized", sourceDOM, function(attr) {
+    var path = attr.nodeValue;
+    if (path.indexOf(pathPrefix) == 0) {
+      path = path.substring(pathPrefix.length);
+      attr.nodeValue = path.replace(DirIO.sep, "/");
+    }
+  });
 };
 
 Pencil.registerDocumentExporter(new BaseRasterizedExporter());


### PR DESCRIPTION
Export image URLs using "/" instead of "%5C", which is "\".

This fixes exporting for Linux / Mac OS while still working locally in Windows with modern browser versions.

This also fixes image loading erros of ODT files.

Implementing the change suggested in https://github.com/prikhi/pencil/issues/225#issuecomment-78844140

Only the line 30 of baseRasterizedExporter.js is changed, the other changes are only autoformatting from my code editor (didn't notice the autoformatting before committing, sorry for that).

I compiled it and tested it, and it successfully fixes issues #225 #222 #641 #512
