### PR TITLE
Make the arrowheads sharper

### DIFF
--- a/app/content/pencil/common/connectorSupports.js
+++ b/app/content/pencil/common/connectorSupports.js
@@ -333,7 +333,7 @@ function arrowTo(startPoints, handle, w, VIA_LENGTH, supportUnconnected,
     if (typeof(withStartArrow) == "undefined") withStartArrow = true;
     if (typeof(withEndArrow) == "undefined") withEndArrow = true;
     
-    const ANGLE = Math.PI / 4;
+    const ANGLE = Math.PI / 8;
     const ARROW_WING_LENGTH = Math.max(w * 4, 6);
     
     if (startPoints[0].x == handle.x &&


### PR DESCRIPTION
The style of the arrows used in the flowchart stencil always annoyed me: they use a 90 degrees angle between the arrow heads.
This simple patch changes that to half that angle. It looks so much better, especially if multiple arrows come together in one point.
