### PR TITLE
Fix #665 for broken command+A

### DIFF
--- a/app/content/pencil/mainWindow.xul
+++ b/app/content/pencil/mainWindow.xul
@@ -413,6 +413,7 @@
         modifiers=""
         keycode="VK_DELETE"/>
       <key id="selectAllKey"
+        command="selectAllCommand"
         modifiers="accel"
         key="A"/>
 


### PR DESCRIPTION
Seems to fix the issue on my osx box... might be a good idea to test on multiple platforms, but I don't see this being an issue... It should only apply to accel+A and not the ctrl+A that also works on OSX(which I discovered in my poking and prodding).

Build with

```
build.sh mac
rm -Rf ~/Library/Caches/Pencil/
```
