### PR TITLE
Added "Duplicate" command

### DIFF
--- a/app/content/pencil/bindings/pCanvas.xbl
+++ b/app/content/pencil/bindings/pCanvas.xbl
@@ -1631,7 +1631,7 @@
                 ]]>
                 </body>
             </method>
-            <method name="doCopy">
+            <method name="getTransferableData">
                 <body>
                 <![CDATA[
 
@@ -1651,12 +1651,12 @@
 
                     var systemString   = Components.classes["@mozilla.org/supports-string;1"].
                                             createInstance(Components.interfaces.nsISupportsString);
-                    if (!systemString) return false;
+                    if (!systemString) return;
                     systemString.data  = textualData;
 
                     var trans = Components.classes["@mozilla.org/widget/transferable;1"].
                                             createInstance(Components.interfaces.nsITransferable);
-                    if (!trans) return false;
+                    if (!trans) return;
 
                     trans.addDataFlavor("text/unicode");
                     trans.setTransferData("text/unicode", systemString, textualData.length * 2);
@@ -1678,7 +1678,7 @@
 
                             var svgXMLSS   = Components.classes["@mozilla.org/supports-string;1"].
                                                     createInstance(Components.interfaces.nsISupportsString);
-                            if (!svgXMLSS) return false;
+                            if (!svgXMLSS) return;
                             svgXMLSS.data = svgXML;
 
                             trans.addDataFlavor("image/svg+xml");
@@ -1687,6 +1687,15 @@
                     } catch (e) {
                         Console.dumpError(e);
                     }
+					return trans;
+                ]]>
+                </body>
+            </method>
+            <method name="doCopy">
+                <body>
+                <![CDATA[
+					var trans = this.getTransferableData();
+                    if (!trans) return false;
 
                     var clipId = Components.interfaces.nsIClipboard;
                     var clip   = Components.classes["@mozilla.org/widget/clipboard;1"].getService(clipId);
@@ -1727,6 +1736,32 @@
                         }
                     }
 
+                ]]>
+                </body>
+            </method>
+            <method name="doDuplicate">
+                <body>
+                <![CDATA[
+					var trans = this.getTransferableData();
+                    if (!trans) return false;
+
+                    for (i in this.xferHelpers) {
+                        var helper = this.xferHelpers[i];
+
+                        var data = new Object();
+                        var length = new Object();
+
+                        try {
+                            trans.getTransferData(helper.type, data, length);
+                        } catch (e) {
+                            continue;
+                        }
+
+                        if (data && length && data.value && length.value) {
+                            helper.handleData(data.value, length.value);
+                            break;
+                        }
+                    }
                 ]]>
                 </body>
             </method>

--- a/app/content/pencil/common/pencil.js
+++ b/app/content/pencil/common/pencil.js
@@ -353,6 +353,7 @@ Pencil.setupCommands = function () {
     Pencil._enableCommand("cutCommand", canvas && canvas.doCopy && target);
     Pencil._enableCommand("pasteCommand", canvas && canvas.doPaste);
     Pencil._enableCommand("deleteSelectedCommand", target != null);
+    Pencil._enableCommand("duplicateCommand", canvas && canvas.doDuplicate && target);
 
     Pencil._enableCommand("groupCommand", target && target.constructor == TargetSet);
     Pencil._enableCommand("unGroupCommand", target && target.constructor == Group);

--- a/app/content/pencil/mainWindow.xul
+++ b/app/content/pencil/mainWindow.xul
@@ -219,7 +219,9 @@
         oncommand="Pencil.activeCanvas.deleteSelected();"/>
       <command id="selectAllCommand"
         oncommand="Pencil.activeCanvas.selectAll();"/>
-
+      <command id="duplicateCommand"
+        oncommand="Pencil.activeCanvas.doDuplicate();"/>
+        
       <command id="groupCommand"
         oncommand="Pencil.activeCanvas.doGroup();"/>
 
@@ -416,6 +418,10 @@
         command="selectAllCommand"
         modifiers="accel"
         key="A"/>
+      <key id="duplicateKey"
+        command="duplicateCommand"
+        modifiers="accel"
+        key="D"/>
 
       <key id="groupKey"
         command="groupCommand"
@@ -609,6 +615,10 @@
                   label="&menu.select.all.label;"
                   key="selectAllKey"
                   command="selectAllCommand"/>
+                <menuitem class="menuitem-iconic duplicate-menu"
+                  label="&menu.duplicate.label;"
+                  key="duplicateKey"
+                  command="duplicateCommand"/>
               </menupopup>
           </menu>
           <menu id="view-menu"


### PR DESCRIPTION
Added a “Duplicate” command which works similar to “Copy” + “Paste”
except that it preserves the existing clipboard content.
The command is present in the “Edit” menu and has CTRL+D
(Windows/Linux”) / CMD+D (Mac) as keyboard shortcut.
