### PR TITLE
Updated name of package

### DIFF
--- a/build/Ubuntu/control
+++ b/build/Ubuntu/control
@@ -1,4 +1,4 @@
-Package: evoluspencil
+Package: pencil-prototyping
 Version: {VERSION}
 Section: devel
 Priority: optional

--- a/build/Ubuntu/control
+++ b/build/Ubuntu/control
@@ -1,4 +1,4 @@
-Package: pencil
+Package: evoluspencil
 Version: {VERSION}
 Section: devel
 Priority: optional


### PR DESCRIPTION
Updated control file to correct package name from pencil to evoluspencil. Ubuntu/Debian repos already have a package called Pencil so this conflicts. Plus earlier packages were called evolus pencil.
