### PR TITLE
Changed pkg_name; closes gh-764, closes gh-499

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -29,7 +29,7 @@ prep() {
     mkdir -p ./Outputs/Pencil/
 
     echo "Configuring build..."
-    PKG_NAME="evolus-pencil"
+    PKG_NAME="pencil"
     XUL_VERSION='36.0.1'        # The version of XULRunner for Private XREs
 
 


### PR DESCRIPTION
The change makes sense since evolus isn't maintaining the package now and it gives a cleaner namespace 
