### PR TITLE
Force the replacement of 2.0.5 #815

### DIFF
--- a/build/Ubuntu/control
+++ b/build/Ubuntu/control
@@ -1,4 +1,6 @@
 Package: {PKG_NAME}
+Replaces: evoluspencil (<< 2.0-6~)
+Breaks: evoluspencil (<< 2.0-6~)
 Version: {VERSION}
 Section: devel
 Priority: optional


### PR DESCRIPTION
Until version 2.0.5 the package was named evoluspencil. Installing the new versions doesn't replace the old packqge creating some confusion for the user.
This patch force the uninstallation of evoluspencil when pencil-prototyping is installed.
