### PR TITLE
Changed the MAX_VERSION to support Firefox 47

### DIFF
--- a/build/properties.sh
+++ b/build/properties.sh
@@ -7,6 +7,6 @@ export AUTHOR='Pavan Rikhi(pavan.rikhi@gmail.com) and Contributors'
 export MAINTAINER='Pavan Rikhi <pavan.rikhi@gmail.com>'
 export XPI_NAME='Pencil-'$VERSION'-firefox.xpi'
 export MIN_VERSION='36.0'
-export MAX_VERSION='46.*'
+export MAX_VERSION='47.*'
 export UPDATE_URL="https://github.com/prikhi/pencil/releases"
 export XULRUNNER_XUL="*"


### PR DESCRIPTION
Should we remove the max version directive, since this _fix_ would need to reapplied every new firefox release?
