### PR TITLE
Add note to Install README.md section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ This file describes all user-facing changes, by version.
 
 # v2.0.21
 
+* Fix FF/XUL Max Version.
+
 # v2.0.19
+
+* Add Support for FF/XUL v52.
+* Add Support for older versions of FF/XUL(v4+).
+* Add French Translation.
+* Add Indonesian Translation.
+* Fix Debian Packages.
 
 # v2.0.18
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ This fork is released under GPLv2 like it's parent codebase.
 
 [releases]: https://github.com/prikhi/pencil/releases
 [amo-pkg]: https://addons.mozilla.org/en-US/firefox/addon/pencil-prototyping/
-[aur-pkg]: https://aur.archlinux.org/packages/pencil/
+[aur-pkg]: https://aur.archlinux.org/packages/pencil-v2/
 [nix-unstable]: https://nixos.org/nixos/manual/sec-upgrading.html
 [graphics-repository]: https://software.opensuse.org/package/pencil
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Download Pencil from [Github][releases] or [Mozilla][amo-pkg]**
 
+**Checkout [Pencil v3][pencil3] from Evolus - But Backup Your Data First!**
+
 [![Documentation Status](https://readthedocs.org/projects/pencil-prototyping/badge/?version=develop)](https://readthedocs.org/projects/pencil-prototyping/?badge=develop)
 [![Join the chat at https://gitter.im/prikhi/pencil](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/prikhi/pencil?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -12,6 +14,7 @@ A GUI prototyping tool for Firefox, GNU/Linux, OS X & Windows.
 ### Status
 
 #### [Pencil v3][pencil3] is in development by Evolus, future work on this fork will be minimal.
+#### Pencil v3 files are not backwards compatible, be sure to backup your data!
 
 This project was originally hosted on https://code.google.com/p/evoluspencil/ &
 was abandoned around 2013. This fork was started for new development on March

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ was abandoned around 2013. This fork was started for new development on March
 * [Bootstrap][bootstrap-collection] by [Nathanielw][nathanielw]
 * [Bootstrap Glyph Icons][bootstrap-icon-collection] by [Craig-Fisk][craigfisk]
 * [Material Design Icons][material-collection] by [Nathanielw][nathanielw]
+* [Polymer Iron Icons][iron-icons-collection] by [MercMobily][mercmobily]
 
 Additional collections are available on the
 [Original Stencil Download Page][evolus-stencil-downloads].
@@ -207,6 +208,8 @@ This fork is released under GPLv2 like it's parent codebase.
 [bootstrap-collection]: https://github.com/nathanielw/Bootstrap-Pencil-Stencils
 [bootstrap-icon-collection]: https://github.com/Craig-Fisk/BootstrapGlyph-Pencil-Stencil
 [craigfisk]: https://github.com/Craig-Fisk
+[iron-icons-collection]: https://github.com/mercmobily/pencil-iron-icons
+[mercmobily]: https://github.com/mercmobily
 
 [nsis]: http://nsis.sourceforge.net/Main_Page
 [sphinx-doc]: http://sphinx-doc.org/

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Additional collections are available on the
 
 * The Native UI Stencil Collection does not load or export correctly, you
   should avoid using this Stencil Collection for now(see #602).
+* Dragging stencils onto the workspace does not work in newer version of
+  Firefox, either use Pale Moon, Xulrunner, an older version of Firefox, or
+  launch Pencil using `firefox --app /path/to/application.ini` (see #802).
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,10 @@ Additional collections are available on the
 
 ## Prerequisites
 
-You will need version 36 or higher of [`firefox`][firefox] to run Pencil as a
-Firefox Extension. Linux users will need version 36 of either `firefox`,
-`iceweasel` or [`xulrunner`][xulrunner]. The Windows installer and OS X archive
+You will need version 4 or higher of [`firefox`][firefox] to run Pencil as a
+Firefox Extension. Linux users will need version 4 or higher of either `firefox`,
+`iceweasel` or [`xulrunner`][xulrunner], or version 25 or higher of
+[`palemoon`][palemoon]. The Windows installer and OS X archive
 has everything you need built-in.
 
 
@@ -195,6 +196,7 @@ This fork is released under GPLv2 like it's parent codebase.
 
 [firefox]: https://www.mozilla.org/firefox/
 [xulrunner]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/XULRunner
+[palemoon]: https://www.palemoon.org/
 
 [releases]: https://github.com/prikhi/pencil/releases
 [amo-pkg]: https://addons.mozilla.org/en-US/firefox/addon/pencil-prototyping/


### PR DESCRIPTION
After firefox browser updated automatically to 62.0 (64-bit), I can't get Pencil Prototyping extension added to my browser as previous and I get a message "Not compatible with Firefox Quantum"